### PR TITLE
feat:IGED-34: Add email verification during authentication

### DIFF
--- a/LaGrandeEcoleDuDroit/Authentication/Data/Repository/Remote/Api/FirebaseAuthApiImpl.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Data/Repository/Remote/Api/FirebaseAuthApiImpl.swift
@@ -12,16 +12,8 @@ class FirebaseAuthApiImpl: FirebaseAuthApi {
         Auth.auth().createUser(withEmail: email, password: password) { authResult, error in
             if let error = error {
                 self.logger.error("FirebaseAuth create user error: \(error.localizedDescription)")
-                let errorCode = AuthErrorCode(rawValue: error._code)
-                switch errorCode {
-                    case .emailAlreadyInUse:
-                        print("Authentication error : Email already in use")
-                        return completion(authResult, error)
-                    default:
-                        print("Authentication error : \(error.localizedDescription)")
-                        completion(authResult, error)
-                }
             }
+            completion(authResult, error)
         }
     }
     
@@ -45,15 +37,16 @@ class FirebaseAuthApiImpl: FirebaseAuthApi {
             return
         }
         
-        currentUser.reload(completion: { error in
-            if let error = error {
-                print("Error while reloading user : \(error.localizedDescription)")
+        currentUser.reload(
+            completion: { error in
+                if let error = error {
+                    self.logger.error("Error while reloading user : \(error.localizedDescription)")
+                    completion(false)
+                    return
+                }
+                
                 completion(false)
-                return
-            }
-            
-            completion(currentUser.isEmailVerified)
-        })
+            })
     }
     
     func signIn(

--- a/LaGrandeEcoleDuDroit/Authentication/Data/Repository/Remote/AuthenticationRemoteRepositoryImpl.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Data/Repository/Remote/AuthenticationRemoteRepositoryImpl.swift
@@ -28,6 +28,8 @@ class AuthenticationRemoteRepositoryImpl: AuthenticationRemoteRepository {
                 switch errorCode {
                 case .userNotFound:
                     completion(.failure(AuthenticationError.userNotFound))
+                case .tooManyRequests:
+                    completion(.failure(AuthenticationError.tooManyRequest))
                 default:
                     completion(.failure(AuthenticationError.unknown))
                 }
@@ -47,6 +49,8 @@ class AuthenticationRemoteRepositoryImpl: AuthenticationRemoteRepository {
                 let errorCode = AuthErrorCode(rawValue: error._code)
                 switch errorCode {
                 case .wrongPassword:
+                    completion(.failure(AuthenticationError.invalidCredentials))
+                case .userNotFound:
                     completion(.failure(AuthenticationError.invalidCredentials))
                 case .userDisabled:
                     completion(.failure(AuthenticationError.userDisabled))

--- a/LaGrandeEcoleDuDroit/Authentication/Domain/Entities/AuthenticationError.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Domain/Entities/AuthenticationError.swift
@@ -5,5 +5,6 @@ enum AuthenticationError: Error {
     case userNotConnected
     case userDisabled
     case network
+    case tooManyRequest
     case unknown
 }

--- a/LaGrandeEcoleDuDroit/Authentication/Domain/Entities/AuthenticationState.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Domain/Entities/AuthenticationState.swift
@@ -1,0 +1,7 @@
+enum AuthenticationState: Equatable {
+    case idle
+    case loading
+    case error(message: String)
+    case authenticated
+    case emailNotVerified
+}

--- a/LaGrandeEcoleDuDroit/Authentication/Domain/Entities/RegistrationState.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Domain/Entities/RegistrationState.swift
@@ -1,0 +1,7 @@
+enum RegistrationState: Equatable {
+    case idle
+    case loading
+    case error(message: String)
+    case registered
+    case emailVerified
+}

--- a/LaGrandeEcoleDuDroit/Authentication/Domain/UseCase/SendVerificationEmailUseCase.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Domain/UseCase/SendVerificationEmailUseCase.swift
@@ -1,14 +1,7 @@
 class SendVerificationEmailUseCase {
     private let authenticationRemoteRepository: AuthenticationRemoteRepository = AuthenticationRemoteRepositoryImpl()
     
-    func execute(completion: @escaping (Bool) -> Void) {
-        authenticationRemoteRepository.sendEmailVerification { result in
-            switch result {
-            case .success:
-                completion(true)
-            case .failure:
-                completion(false)
-            }
-        }
+    func execute(completion: @escaping (Result<Void, AuthenticationError>) -> Void) {
+        return authenticationRemoteRepository.sendEmailVerification(completion: completion)
     }
 }

--- a/LaGrandeEcoleDuDroit/Authentication/Presentation/Views/EmailVerificationView.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Presentation/Views/EmailVerificationView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct EmailVerificationView: View {
     @EnvironmentObject private var registrationViewModel: RegistrationViewModel
-    @Environment(\.presentationMode) var presentationMode
     @State private var isValid = false
     @State private var isAnimating = false
     
@@ -16,10 +15,10 @@ struct EmailVerificationView: View {
                     )
                 ).font(.title3)
                 
-                if registrationViewModel.errorMessage != nil {
+                if case .error(let message) = registrationViewModel.registrationState {
                     HStack {
                         Image(systemName: "exclamationmark.octagon")
-                        Text(registrationViewModel.errorMessage!)
+                        Text(message)
                     }.foregroundStyle(Color.red)
                 }
                 
@@ -38,10 +37,6 @@ struct EmailVerificationView: View {
                 
                 HStack {
                     Spacer()
-                    NavigationLink(
-                        destination: EmailVerificationView(),
-                        isActive: $registrationViewModel.isEmailVerified
-                    ) {
                         Button(action: {
                             registrationViewModel.checkVerifiedEmail()
                         }) {
@@ -49,24 +44,14 @@ struct EmailVerificationView: View {
                                 .tint(Color(GedColor.primary))
                                 .font(.title2)
                         }
-                    }
-                }
-                .padding()
+                }.padding()
             }
             .onAppear {
-                registrationViewModel.resetErrorMessage()
                 registrationViewModel.sendVerificationEmail()
             }
             .navigationTitle(getString(gedString: GedString.email_verification_title))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .padding()
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    BackButton(action: {
-                        presentationMode.wrappedValue.dismiss()
-                    })
-                }
-            }
             
         }.navigationBarBackButtonHidden()
     }

--- a/LaGrandeEcoleDuDroit/Authentication/Presentation/Views/FirstRegistrationView.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Presentation/Views/FirstRegistrationView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 struct FirstRegistrationView: View {
-    @StateObject private var registrationViewModel = RegistrationViewModel()
+    @EnvironmentObject private var registrationViewModel: RegistrationViewModel
     @State private var inputFocused: InputField?
-    @State private var isValid = false
-    private let titleFirstNameTextField = getString(gedString: GedString.firstName)
-    private let titleLastNameTextField = getString(gedString: GedString.lastName)
+    @State private var isValidNameInputs = false
+    private let firstNameTextFieldTitle = getString(gedString: GedString.firstName)
+    private let lastNameTextFieldTitle = getString(gedString: GedString.lastName)
     @Environment(\.presentationMode) var presentationMode
 
     var body: some View {
@@ -15,21 +15,21 @@ struct FirstRegistrationView: View {
                     .font(.title2)
                 
                 FocusableOutlinedTextField(
-                    title: titleFirstNameTextField,
+                    title: firstNameTextFieldTitle,
                     text: $registrationViewModel.firstName,
                     defaultFocusValue: InputField.firstName,
                     inputFocused: $inputFocused
                 )
                 
                 FocusableOutlinedTextField(
-                    title: titleLastNameTextField,
+                    title: lastNameTextFieldTitle,
                     text: $registrationViewModel.lastName,
                     defaultFocusValue: InputField.lastName,
                     inputFocused: $inputFocused
                 )
                 
-                if registrationViewModel.errorMessage != nil {
-                    Text(registrationViewModel.errorMessage!)
+                if case .error(let message) = registrationViewModel.registrationState {
+                    Text(message)
                         .foregroundColor(.red)
                 }
                 
@@ -38,12 +38,11 @@ struct FirstRegistrationView: View {
                 HStack {
                     Spacer()
                     NavigationLink(
-                        destination: SecondRegistrationView()
-                            .environmentObject(registrationViewModel),
-                        isActive: $isValid
+                        destination: SecondRegistrationView().environmentObject(registrationViewModel),
+                        isActive: $isValidNameInputs
                     ) {
                         Button(action: {
-                            isValid = registrationViewModel.validateNameInputs()
+                            isValidNameInputs = registrationViewModel.validateNameInputs()
                         }) {
                             Text(getString(gedString: GedString.next))
                                 .tint(Color(GedColor.primary))
@@ -53,7 +52,8 @@ struct FirstRegistrationView: View {
                 }
                 .padding()
             }
-            .navigationTitle(getString(gedString: GedString.registration)).navigationBarTitleDisplayMode(.inline)
+            .navigationTitle(getString(gedString: GedString.registration))
+            .navigationBarTitleDisplayMode(.inline)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(Color(UIColor.systemBackground))
             .padding()

--- a/LaGrandeEcoleDuDroit/Authentication/Presentation/Views/SecondRegistrationView.swift
+++ b/LaGrandeEcoleDuDroit/Authentication/Presentation/Views/SecondRegistrationView.swift
@@ -45,10 +45,10 @@ struct SecondRegistrationView: View {
                             .tint(Color(GedColor.primary))
                             .font(.title2)
                     }
-                }
-                .padding()
+                }.padding()
             }
-            .navigationTitle(getString(gedString: GedString.registration)).navigationBarTitleDisplayMode(.inline)
+            .navigationTitle(getString(gedString: GedString.registration))
+            .navigationBarTitleDisplayMode(.inline)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .padding()
             .toolbar {

--- a/LaGrandeEcoleDuDroit/Common/Extensions/StringExtensions.swift
+++ b/LaGrandeEcoleDuDroit/Common/Extensions/StringExtensions.swift
@@ -1,0 +1,17 @@
+extension String {
+    func trimmedAndCapitalized() -> String {
+        // Trim the string
+        let trimmedText = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // Check if the trimmed text is empty
+        guard !trimmedText.isEmpty else {
+            return ""
+        }
+        
+        // Capitalize the first letter
+        let firstLetter = trimmedText.prefix(1).uppercased()
+        let remainingText = trimmedText.dropFirst()
+        
+        return firstLetter + remainingText
+    }
+}

--- a/LaGrandeEcoleDuDroit/LaGrandeEcolueDuDroitApp.swift
+++ b/LaGrandeEcoleDuDroit/LaGrandeEcolueDuDroitApp.swift
@@ -16,10 +16,34 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 @main
 struct LaGrandeEcolueDuDroitApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
-    
+    @StateObject private var authenticationViewModel = AuthenticationViewModel()
+    @StateObject private var registrationViewModel = RegistrationViewModel()
+    @State private var isAuthenticated: Bool = false
+
     var body: some Scene {
         WindowGroup {
-            AuthenticationView()
+            NavigationView {
+                HStack {
+                    if isAuthenticated {
+                        NewsView()
+                    } else {
+                        AuthenticationView()
+                            .environmentObject(authenticationViewModel)
+                            .environmentObject(registrationViewModel)
+                    }
+                }
+                .onReceive(authenticationViewModel.$authenticationState) { state in
+                    if state == .authenticated {
+                        isAuthenticated = true
+                    }
+                }
+                .onReceive(registrationViewModel.$registrationState) { state in
+                    if state == .emailVerified {
+                        isAuthenticated = true
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            }
         }
     }
 }

--- a/LaGrandeEcoleDuDroit/Resources/GedString.swift
+++ b/LaGrandeEcoleDuDroit/Resources/GedString.swift
@@ -2,6 +2,8 @@ struct GedString {
     static let appName = "app_name"
     static let next = "next"
     static let back = "back"
+    static let cancel = "cancel"
+    static let ok = "ok"
     
     //Authentication
     static let authenticationPageTitle = "authentication_page_title"
@@ -23,16 +25,21 @@ struct GedString {
     static let email_verification_title = "email_verification_title"
     static let email_verification_explanation = "email_verification_explanation"
     static let send_email_verification_caption = "send_email_verification_caption"
+    static let email_not_verified = "email_not_verified"
+    static let email_not_verified_dialog_message = "email_not_verified_dialog_message"
+    static let verify_email = "verify_email"
     
     // Authentication error
     static let invalid_email_error = "invalid_email_error"
     static let password_length_error = "password_length_error"
     static let invalid_credentials = "invalid_credentials"
     static let user_disabled = "user_disabled"
+    static let user_not_found = "user_not_found"
     static let email_not_verified_error = "email_not_verified_error"
     static let registration_error = "registration_error"
     static let account_already_in_use_error = "account_already_in_use_error"
     static let unknown_error = "unknown_error"
+    static let too_many_request_error = "too_many_request_error"
     
     
     static let empty_inputs_error = "empty_inputs_error"

--- a/LaGrandeEcoleDuDroit/en.lproj/Localizable.strings
+++ b/LaGrandeEcoleDuDroit/en.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 "app_name" = "La Grande Ecole du Droit";
 "next" = "Next";
 "back" = "Back";
+"cancel" = "Cancel";
+"ok" = "Ok";
 
 //Authentication
 "authentication_page_title" = "Login or sign up on Gedoise application";
@@ -21,16 +23,21 @@
 "enter_email_password" = "Enter your email and password";
 "email_verification_title" = "Email verification";
 "email_verification_explanation" = "A link has been sent to the following address : %@. Please click on it to complete registration.";
-"send_email_verification_caption" = "A verification link will be sent to the mail adress.";
+"send_email_verification_caption" = "A verification link will be sent.";
+"email_not_verified" = "Email not verified";
+"email_not_verified_dialog_message" = "Please confirm your email before to continue.";
+"verify_email" = "Verify email";
 
 "invalid_email_error" = "Please enter a valid email address.";
 "password_length_error" = "The password must be at least 8 characters long.";
 "invalid_credentials" = "Incorrect email address or password.";
-"user_disabled" = "The user account is disabled. Please contact the support: application.ged@gmail.com";
+"user_disabled" = "This account is disabled. Please contact the support: application.ged@gmail.com to re-enabled it";
+"user_not_found" = "User not found. Please re-authenticate and try again.";
 "email_not_verified_error" = "Please validate your email address before to continue.";
 "registration_error" = "An error occured while registration";
 "account_already_in_use_error" = "The account is already in use. Please log in or reset your password.";
-"unknown_error" = "An unknown error has occured";
+"unknown_error" = "An unknown error has occured. Please try again.";
+"too_many_request_error" = "You have made too many requests. Please try again in a few minutes.";
 
 "empty_inputs_error" = "Please fill out all fields.";
 

--- a/LaGrandeEcoleDuDroit/fr.lproj/Localizable.strings
+++ b/LaGrandeEcoleDuDroit/fr.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 "app_name" = "La Grande Ecole du Droit";
 "next" = "Suivant";
 "back" = "Retour";
+"cancel" = "Annuler";
+"ok" = "Ok";
 
 //Authentication
 "authentication_page_title" = "Connectez-vous ou inscrivez-vous sur l'applicaion Gédoise";
@@ -21,16 +23,21 @@
 "enter_email_password" = "Entrez votre adresse mail et votre mot de passe";
 "email_verification_title" = "Vérification de l'email";
 "email_verification_explanation" = "Un lien a été à l'adresse suivante : %@. Veuillez cliquez dessus pour terminer l'inscription";
-"send_email_verification_caption" = "Un lien de vérification sera envoyé à l'adresse mail.";
+"send_email_verification_caption" = "Un lien de vérification sera envoyé.";
+"email_not_verified" = "Email non vérifié";
+"email_not_verified_dialog_message" = "Veuillez vérifier votre adresse mail avant de continuer.";
+"verify_email" = "Vérifier l'email";
 
 "invalid_email_error" = "Veuillez entrer une adresse mail valide.";
 "password_length_error" = "Le mot de passe doit faire au moins 8 caractères.";
 "invalid_credentials" = "Adresse email ou mot de passe incorrect.";
-"user_disabled" = "Le compte de cet utilisateur est désactivé. Veuillez contacter le support: application.ged@gmail.com";
+"user_disabled" = "Ce compte est désactivé. Veuillez contacter le support: application.ged@gmail.com pour le réactiver";
+"user_not_found" = "L'utilisateur n'a pas été trouvé. Veuillez vous re-authentifier puis réessayer.";
 "email_not_verified_error" = "Veuillez validez votre adresse mail avant de continuer.";
 "registration_error" = "Une erreur est survenue lors de l'inscription.";
 "account_already_in_use_error" = "Le compte est déjà utilisé. Veuillez vous connecter ou réinitialiser votre mot de passe.";
-"unknown_error" = "Une erreur inconnue est survenue.";
+"unknown_error" = "Une erreur inconnue est survenue. Veuillez réessayer";
+"too_many_request_error" = "Vous avez effectué trop de requêtes. Veuillez réessayer dans quelques minutes.";
 
 "empty_inputs_error" = "Veuillez remplir tous les champs.";
 


### PR DESCRIPTION
Replace old state variables by enum state in AuthenticationViewModel and RegistrationViewModel. Call the authenticationView or the home page view from the App file to prevent to go back login view after having been authenticated. Add alert dialog in AuthenticationView which redirect to the EmailVerificationView if the user exist but has not yet validated his email.